### PR TITLE
Fix auto-commit/push pipeline and 5 related issues

### DIFF
--- a/custom_components/git_ha_ppens/__init__.py
+++ b/custom_components/git_ha_ppens/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     ATTR_MESSAGE,
@@ -17,6 +19,7 @@ from .const import (
     CONF_AUTH_METHOD,
     CONF_AUTH_TOKEN,
     CONF_AUTO_COMMIT,
+    CONF_AUTO_PUSH,
     CONF_COMMIT_INTERVAL,
     CONF_GIT_EMAIL,
     CONF_GIT_USER,
@@ -93,8 +96,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.info(
                     "Created initial commit: %s", commit_info.hash_short
                 )
+                # Auto-push initial commit if remote is configured
+                if remote_url and data.get(CONF_AUTO_PUSH, True):
+                    try:
+                        commits_pushed = await git_manager.push()
+                        _LOGGER.info(
+                            "Initial push: %d commit(s) pushed to remote",
+                            commits_pushed,
+                        )
+                    except GitError as push_err:
+                        _LOGGER.warning(
+                            "Initial push failed (will retry on next auto-push): %s",
+                            push_err,
+                        )
+            else:
+                _LOGGER.warning(
+                    "Initial commit returned None — no changes to commit"
+                )
         except GitError as err:
-            _LOGGER.warning("Failed to create initial commit: %s", err)
+            _LOGGER.error(
+                "Failed to create initial commit: %s. "
+                "Check file permissions in %s and .gitignore configuration.",
+                err,
+                repo_path,
+            )
 
     # Configure remote if specified
     remote_url = data.get(CONF_REMOTE_URL, "")
@@ -124,14 +149,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Setup file watcher for auto-commit
     file_watcher: GitFileWatcher | None = None
+    periodic_unsub = None
     if data.get(CONF_AUTO_COMMIT, False):
         commit_interval = data.get(CONF_COMMIT_INTERVAL, 300)
+        auto_push = data.get(CONF_AUTO_PUSH, True)
         file_watcher = GitFileWatcher(
-            hass, git_manager, coordinator, repo_path, commit_interval
+            hass,
+            git_manager,
+            coordinator,
+            repo_path,
+            commit_interval,
+            auto_push=auto_push,
+            remote_configured=bool(remote_url),
         )
         await file_watcher.async_start()
         _LOGGER.info(
-            "Auto-commit enabled with %ds debounce interval", commit_interval
+            "Auto-commit enabled with %ds debounce interval (auto-push: %s)",
+            commit_interval,
+            auto_push,
+        )
+
+        # Periodic fallback: check for changes even if watchdog misses events
+        async def _periodic_check(_now) -> None:
+            """Periodic fallback to catch changes watchdog may have missed."""
+            if file_watcher and file_watcher.is_running:
+                await file_watcher.async_check_and_commit()
+
+        periodic_unsub = async_track_time_interval(
+            hass, _periodic_check, timedelta(seconds=commit_interval)
         )
 
     # Store references
@@ -139,6 +184,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "git_manager": git_manager,
         "coordinator": coordinator,
         "file_watcher": file_watcher,
+        "periodic_unsub": periodic_unsub,
     }
 
     # Forward platform setup
@@ -178,8 +224,13 @@ async def _async_update_options(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    # Stop file watcher
+    # Cancel periodic fallback
     entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    periodic_unsub = entry_data.get("periodic_unsub")
+    if periodic_unsub:
+        periodic_unsub()
+
+    # Stop file watcher
     file_watcher: GitFileWatcher | None = entry_data.get("file_watcher")
     if file_watcher:
         await file_watcher.async_stop()

--- a/custom_components/git_ha_ppens/config_flow.py
+++ b/custom_components/git_ha_ppens/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_AUTH_METHOD,
     CONF_AUTH_TOKEN,
     CONF_AUTO_COMMIT,
+    CONF_AUTO_PUSH,
     CONF_COMMIT_INTERVAL,
     CONF_GIT_EMAIL,
     CONF_GIT_USER,
@@ -97,6 +98,7 @@ class GitHaPpensConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_AUTO_COMMIT, default=True): bool,
+                    vol.Required(CONF_AUTO_PUSH, default=True): bool,
                     vol.Required(
                         CONF_COMMIT_INTERVAL,
                         default=DEFAULT_COMMIT_INTERVAL,
@@ -219,6 +221,10 @@ class GitHaPpensOptionsFlow(OptionsFlow):
                     vol.Required(
                         CONF_AUTO_COMMIT,
                         default=current.get(CONF_AUTO_COMMIT, True),
+                    ): bool,
+                    vol.Required(
+                        CONF_AUTO_PUSH,
+                        default=current.get(CONF_AUTO_PUSH, True),
                     ): bool,
                     vol.Required(
                         CONF_COMMIT_INTERVAL,

--- a/custom_components/git_ha_ppens/const.py
+++ b/custom_components/git_ha_ppens/const.py
@@ -12,6 +12,7 @@ CONF_REPO_PATH: Final = "repo_path"
 CONF_GIT_USER: Final = "git_user"
 CONF_GIT_EMAIL: Final = "git_email"
 CONF_AUTO_COMMIT: Final = "auto_commit"
+CONF_AUTO_PUSH: Final = "auto_push"
 CONF_COMMIT_INTERVAL: Final = "commit_interval"
 CONF_REMOTE_URL: Final = "remote_url"
 CONF_AUTH_METHOD: Final = "auth_method"
@@ -89,6 +90,17 @@ DEFAULT_GITIGNORE_ENTRIES: Final = [
     "deps/",
     "tts/",
     ".venv/",
+    "",
+    "# Sensitive/runtime files",
+    ".jwt_secret",
+    "SERVICE_ACCOUNT.json",
+    ".cache/",
+    ".claude/",
+    "ip_bans.yaml",
+    ".ha_run.lock",
+    ".exports",
+    ".timeline",
+    ".vacuum",
 ]
 
 # Secret detection patterns (regex)

--- a/custom_components/git_ha_ppens/file_watcher.py
+++ b/custom_components/git_ha_ppens/file_watcher.py
@@ -12,7 +12,7 @@ from watchdog.observers import Observer
 
 from homeassistant.core import HomeAssistant
 
-from .const import EVENT_COMMIT, EVENT_ERROR, WATCHER_IGNORE_PATTERNS
+from .const import EVENT_COMMIT, EVENT_ERROR, EVENT_PUSH, WATCHER_IGNORE_PATTERNS
 from .coordinator import GitHaPpensCoordinator
 from .git_manager import GitError, GitManager
 
@@ -116,6 +116,8 @@ class GitFileWatcher:
         coordinator: GitHaPpensCoordinator,
         repo_path: str,
         debounce_seconds: int = 300,
+        auto_push: bool = False,
+        remote_configured: bool = False,
     ) -> None:
         """Initialize the file watcher."""
         self._hass = hass
@@ -123,6 +125,8 @@ class GitFileWatcher:
         self._coordinator = coordinator
         self._repo_path = repo_path
         self._debounce_seconds = debounce_seconds
+        self._auto_push = auto_push
+        self._remote_configured = remote_configured
         self._observer: Observer | None = None
         self._change_collector: _ChangeCollector | None = None
         self._debounce_handle: asyncio.TimerHandle | None = None
@@ -220,6 +224,26 @@ class GitFileWatcher:
                     commit_info.hash_short,
                     commit_info.message,
                 )
+
+                # Auto-push if enabled and remote is configured
+                if self._auto_push and self._remote_configured:
+                    try:
+                        commits_pushed = await self._git_manager.push()
+                        self._hass.bus.async_fire(
+                            EVENT_PUSH,
+                            {"commits_pushed": commits_pushed, "auto": True},
+                        )
+                        _LOGGER.info(
+                            "Auto-push: %d commit(s) pushed to remote",
+                            commits_pushed,
+                        )
+                    except GitError as push_err:
+                        _LOGGER.error("Auto-push failed: %s", push_err)
+                        self._hass.bus.async_fire(
+                            EVENT_ERROR,
+                            {"operation": "auto_push", "error": str(push_err)},
+                        )
+
                 await self._coordinator.async_request_refresh()
         except GitError as err:
             _LOGGER.error("Auto-commit failed: %s", err)
@@ -229,10 +253,26 @@ class GitFileWatcher:
             )
 
     async def async_check_and_commit(self) -> None:
-        """Check for accumulated changes and commit if any exist.
+        """Check for changes and commit if any exist.
 
-        Called periodically or on demand to process collected changes.
+        Called periodically as a fallback when watchdog events may not fire
+        (e.g. on Docker overlay filesystems). Also handles accumulated changes
+        from the file watcher.
         """
-        if not self._change_collector or not self._change_collector.changed_files:
+        # First check collector for watchdog-detected changes
+        if self._change_collector and self._change_collector.changed_files:
+            await self._async_auto_commit()
             return
-        await self._async_auto_commit()
+
+        # Fallback: ask git directly if there are uncommitted changes
+        try:
+            porcelain = await self._git_manager._run_git(
+                "status", "--porcelain", check=False
+            )
+            if porcelain and porcelain.strip():
+                _LOGGER.debug(
+                    "Periodic check found uncommitted changes (watchdog fallback)"
+                )
+                await self._async_auto_commit()
+        except GitError:
+            pass

--- a/custom_components/git_ha_ppens/git_manager.py
+++ b/custom_components/git_ha_ppens/git_manager.py
@@ -173,14 +173,26 @@ class GitManager:
         if self._git_email:
             await self._run_git("config", "user.email", self._git_email)
 
-        # Set default branch name
+        # Set default branch name for future inits
         await self._run_git("config", "init.defaultBranch", "main", check=False)
+
+        # Normalize branch to "main" if repo has no commits yet (unborn HEAD)
+        if not await self.has_commits():
+            current_branch = await self._run_git(
+                "rev-parse", "--abbrev-ref", "HEAD", check=False
+            )
+            if current_branch and current_branch != "main" and "fatal" not in current_branch:
+                await self._run_git("branch", "-M", "main", check=False)
+                _LOGGER.info("Renamed branch from %s to main", current_branch)
 
     async def has_commits(self) -> bool:
         """Check if the repository has any commits."""
         try:
-            result = await self._run_git("rev-parse", "HEAD", check=False)
-            return bool(result) and "fatal" not in result
+            result = await self._run_git(
+                "rev-parse", "--verify", "HEAD", check=False
+            )
+            # A valid commit hash is 40 hex chars; anything else means no commits
+            return bool(result) and len(result) >= 40 and "fatal" not in result.lower()
         except GitError:
             return False
 

--- a/custom_components/git_ha_ppens/sensor.py
+++ b/custom_components/git_ha_ppens/sensor.py
@@ -86,6 +86,10 @@ def _format_remote_status(status: GitStatus) -> str:
     if not status.remote_configured:
         return "no remote"
 
+    # A repo with 0 commits can't be "in sync" — nothing has been pushed yet
+    if status.total_commits == 0:
+        return "not pushed"
+
     parts: list[str] = []
     if status.ahead > 0:
         parts.append(f"ahead {status.ahead}")

--- a/custom_components/git_ha_ppens/strings.json
+++ b/custom_components/git_ha_ppens/strings.json
@@ -20,11 +20,13 @@
         "description": "Configure automatic commit behavior.",
         "data": {
           "auto_commit": "Enable auto-commit on file changes",
+          "auto_push": "Enable auto-push after each commit",
           "commit_interval": "Auto-commit debounce interval (seconds)",
           "scan_interval": "Status polling interval (seconds)"
         },
         "data_description": {
           "auto_commit": "Automatically commit when configuration files change.",
+          "auto_push": "Automatically push to the remote repository after each auto-commit. Requires a configured remote.",
           "commit_interval": "Wait this many seconds after the last change before auto-committing. Minimum 30, maximum 86400 (24h).",
           "scan_interval": "How often to poll the git status for sensor updates. Minimum 10, maximum 3600."
         }
@@ -66,6 +68,7 @@
           "git_user": "Git user name",
           "git_email": "Git email",
           "auto_commit": "Enable auto-commit",
+          "auto_push": "Enable auto-push after each commit",
           "commit_interval": "Auto-commit debounce interval (seconds)",
           "scan_interval": "Status polling interval (seconds)",
           "remote_url": "Remote URL",

--- a/custom_components/git_ha_ppens/translations/en.json
+++ b/custom_components/git_ha_ppens/translations/en.json
@@ -20,11 +20,13 @@
         "description": "Configure automatic commit behavior.",
         "data": {
           "auto_commit": "Enable auto-commit on file changes",
+          "auto_push": "Enable auto-push after each commit",
           "commit_interval": "Auto-commit debounce interval (seconds)",
           "scan_interval": "Status polling interval (seconds)"
         },
         "data_description": {
           "auto_commit": "Automatically commit when configuration files change.",
+          "auto_push": "Automatically push to the remote repository after each auto-commit. Requires a configured remote.",
           "commit_interval": "Wait this many seconds after the last change before auto-committing. Minimum 30, maximum 86400 (24h).",
           "scan_interval": "How often to poll the git status for sensor updates. Minimum 10, maximum 3600."
         }
@@ -66,6 +68,7 @@
           "git_user": "Git user name",
           "git_email": "Git email",
           "auto_commit": "Enable auto-commit",
+          "auto_push": "Enable auto-push after each commit",
           "commit_interval": "Auto-commit debounce interval (seconds)",
           "scan_interval": "Status polling interval (seconds)",
           "remote_url": "Remote URL",


### PR DESCRIPTION
## Summary

- **Auto-Push nach Commits** (Problem 3): FileWatcher pusht jetzt automatisch nach jedem erfolgreichen Auto-Commit zum Remote — neues `auto_push` Config-Toggle (default: an)
- **Periodischer Fallback** (Problem 2): `async_track_time_interval` prüft regelmäßig auf Änderungen, falls watchdog auf Docker/Overlay-FS keine Events feuert
- **Initialer Commit + Push** (Problem 1): Verbessertes Error-Handling mit detailliertem Logging; automatischer Push des Initial-Commits wenn Remote konfiguriert
- **Remote-Status Fix** (Problem 4): Zeigt "not pushed" statt "in sync" bei Repos mit 0 Commits
- **Branch-Normalisierung** (Problem 5): Benennt `master` → `main` bei Repos ohne Commits um, verhindert Push-Fehler zu GitHub
- **Erweiterte .gitignore** (Problem 6): Fehlende sensible Dateien ergänzt (`.jwt_secret`, `SERVICE_ACCOUNT.json`, `.cache/`, `.claude/`, `ip_bans.yaml`, etc.)

## Test plan

- [ ] Integration installieren und konfigurieren (mit Remote-URL + Token)
- [ ] Prüfen, dass Initial-Commit + Push automatisch erfolgt
- [ ] Config-Datei ändern und warten, ob Auto-Commit + Auto-Push nach Debounce-Interval erfolgt
- [ ] Remote-Status-Sensor prüft korrekt "not pushed" → "in sync" nach Push
- [ ] Branch-Sensor zeigt "main" (nicht "master")
- [ ] `.gitignore` enthält alle neuen Einträge
- [ ] Auto-Push in Options Flow deaktivieren → nur Commits, keine Pushes
- [ ] Periodic Fallback testen: watchdog stoppen, Datei ändern, auf nächsten Intervall-Check warten

https://claude.ai/code/session_01YCNAibq5TqX1jKhHvm6QTU