### PR TITLE
fix: resolve push failures and false "in sync" status

### DIFF
--- a/custom_components/git_ha_ppens/__init__.py
+++ b/custom_components/git_ha_ppens/__init__.py
@@ -86,6 +86,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except GitError as err:
         _LOGGER.warning("Failed to update .gitignore: %s", err)
 
+    # Configure remote if specified (must happen BEFORE initial commit so push works)
+    remote_url = data.get(CONF_REMOTE_URL, "")
+    if remote_url:
+        try:
+            auth_method = data.get(CONF_AUTH_METHOD, "")
+            if auth_method == AUTH_TOKEN:
+                token = data.get(CONF_AUTH_TOKEN, "")
+                if token:
+                    await git_manager.configure_token_auth(remote_url, token)
+                else:
+                    await git_manager.set_remote(remote_url)
+            elif auth_method == AUTH_SSH:
+                ssh_key = data.get(CONF_SSH_KEY_PATH, "")
+                await git_manager.set_remote(remote_url)
+                if ssh_key:
+                    await git_manager.configure_ssh_auth(ssh_key)
+            else:
+                await git_manager.set_remote(remote_url)
+        except GitError as err:
+            _LOGGER.warning("Failed to configure remote: %s", err)
+
     # Create initial commit if repository has no commits yet
     if not await git_manager.has_commits():
         try:
@@ -120,27 +141,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 err,
                 repo_path,
             )
-
-    # Configure remote if specified
-    remote_url = data.get(CONF_REMOTE_URL, "")
-    if remote_url:
-        try:
-            auth_method = data.get(CONF_AUTH_METHOD, "")
-            if auth_method == AUTH_TOKEN:
-                token = data.get(CONF_AUTH_TOKEN, "")
-                if token:
-                    await git_manager.configure_token_auth(remote_url, token)
-                else:
-                    await git_manager.set_remote(remote_url)
-            elif auth_method == AUTH_SSH:
-                ssh_key = data.get(CONF_SSH_KEY_PATH, "")
-                await git_manager.set_remote(remote_url)
-                if ssh_key:
-                    await git_manager.configure_ssh_auth(ssh_key)
-            else:
-                await git_manager.set_remote(remote_url)
-        except GitError as err:
-            _LOGGER.warning("Failed to configure remote: %s", err)
 
     # Create coordinator
     scan_interval = data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)

--- a/custom_components/git_ha_ppens/git_manager.py
+++ b/custom_components/git_ha_ppens/git_manager.py
@@ -283,6 +283,9 @@ class GitManager:
                 # Check if remote origin exists even without tracking
                 remotes = await self._run_git("remote", check=False)
                 status.remote_configured = bool(remotes.strip())
+                # No tracking branch = we don't know ahead/behind
+                if status.remote_configured and status.total_commits > 0:
+                    status.ahead = -1  # Convention: -1 = unknown/not pushed
         except (GitError, ValueError):
             pass
 
@@ -373,7 +376,23 @@ class GitManager:
         # Get the current branch
         branch = await self._run_git("rev-parse", "--abbrev-ref", "HEAD")
 
-        await self._run_git("push", "-u", "origin", branch)
+        try:
+            await self._run_git("push", "-u", "origin", branch)
+        except GitError as err:
+            error_str = str(err).lower()
+            # Handle divergent histories (e.g. remote initialized with README)
+            if "non-fast-forward" in error_str or "rejected" in error_str:
+                _LOGGER.warning(
+                    "Push rejected — attempting to merge remote changes"
+                )
+                await self._run_git(
+                    "pull", "--allow-unrelated-histories",
+                    "--no-edit", "origin", branch
+                )
+                await self._run_git("push", "-u", "origin", branch)
+            else:
+                raise
+
         _LOGGER.info("Pushed %d commit(s) to origin/%s", ahead, branch)
         return ahead
 

--- a/custom_components/git_ha_ppens/sensor.py
+++ b/custom_components/git_ha_ppens/sensor.py
@@ -90,6 +90,10 @@ def _format_remote_status(status: GitStatus) -> str:
     if status.total_commits == 0:
         return "not pushed"
 
+    # ahead == -1 means remote exists but no upstream tracking (never pushed)
+    if status.ahead == -1:
+        return "not pushed"
+
     parts: list[str] = []
     if status.ahead > 0:
         parts.append(f"ahead {status.ahead}")


### PR DESCRIPTION
## Summary
- **Fix 1 — `__init__.py`:** Move remote configuration (auth + set_remote) **before** the initial commit block. Previously `remote_url` was referenced before being defined, causing a `NameError` on fresh installs and preventing the first push from ever happening.
- **Fix 2 — `git_manager.py`:** Handle divergent histories in `push()`. When the GitHub repo was initialized with a README, the push is rejected due to unrelated histories. Now automatically runs `git pull --allow-unrelated-histories --no-edit` and retries.
- **Fix 3 — `git_manager.py` + `sensor.py`:** Show "not pushed" instead of false "in sync" when a remote is configured but no upstream tracking branch exists (commits were never successfully pushed).

## Test plan
- [ ] Fresh install: configure integration with a GitHub repo that has a README → verify initial commit + push succeeds automatically
- [ ] Fresh install: configure integration with an empty GitHub repo → verify initial commit + push succeeds
- [ ] Check sensor: after failed push (no tracking branch), remote_status should show "not pushed" instead of "in sync"
- [ ] After successful push, remote_status should show "in sync"
- [ ] Verify auto-commit + auto-push cycle works end-to-end after initial setup

https://claude.ai/code/session_01YSoZXpHw5KvE12P4RjTxie