### PR TITLE
fix: validate remote before push/pull to prevent cascading errors

### DIFF
--- a/custom_components/git_ha_ppens/__init__.py
+++ b/custom_components/git_ha_ppens/__init__.py
@@ -104,8 +104,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     await git_manager.configure_ssh_auth(ssh_key)
             else:
                 await git_manager.set_remote(remote_url)
+
+            # Verify remote was actually configured correctly
+            if await git_manager.is_remote_configured():
+                configured_url = await git_manager.get_remote_url()
+                _LOGGER.info(
+                    "Remote origin verified: %s",
+                    GitManager._redact_url(configured_url),
+                )
+            else:
+                _LOGGER.error(
+                    "Remote origin could not be verified after configuration. "
+                    "The URL '%s' may be invalid. Push/pull will be disabled. "
+                    "Check the remote URL in the integration options.",
+                    remote_url,
+                )
+                remote_url = ""  # Prevent push attempts
         except GitError as err:
-            _LOGGER.warning("Failed to configure remote: %s", err)
+            _LOGGER.error(
+                "Failed to configure remote: %s. Push/pull will be disabled.",
+                err,
+            )
+            remote_url = ""  # Prevent push attempts
 
     # Create initial commit if repository has no commits yet
     if not await git_manager.has_commits():

--- a/custom_components/git_ha_ppens/git_manager.py
+++ b/custom_components/git_ha_ppens/git_manager.py
@@ -207,6 +207,28 @@ class GitManager:
         except GitError:
             return False
 
+    async def is_remote_configured(self) -> bool:
+        """Check if the remote 'origin' is configured with a valid URL."""
+        try:
+            result = await self._run_git(
+                "remote", "get-url", "origin", check=False
+            )
+            return bool(result) and "fatal" not in result.lower() and "error" not in result.lower()
+        except GitError:
+            return False
+
+    async def get_remote_url(self) -> str:
+        """Return the configured remote URL (empty string if not set)."""
+        try:
+            result = await self._run_git(
+                "remote", "get-url", "origin", check=False
+            )
+            if result and "fatal" not in result.lower() and "error" not in result.lower():
+                return result
+        except GitError:
+            pass
+        return ""
+
     async def get_status(self) -> GitStatus:
         """Get the complete repository status."""
         status = GitStatus()
@@ -380,6 +402,14 @@ class GitManager:
         Raises:
             GitError: If push fails after all retry attempts.
         """
+        # Pre-check: verify remote is configured before attempting any push
+        if not await self.is_remote_configured():
+            raise GitError(
+                "Remote 'origin' is not configured. "
+                "Please set a valid remote URL in the integration options "
+                "(Settings → Devices & Services → git-ha-ppens → Configure)."
+            )
+
         branch = await self._run_git("rev-parse", "--abbrev-ref", "HEAD")
         has_upstream = await self._has_upstream()
 
@@ -415,7 +445,7 @@ class GitManager:
             error_lower = str(err).lower()
             _LOGGER.warning("Push attempt 1 failed: %s", err)
 
-            # Check if it's a permission/auth error — don't retry these
+            # Check if it's a permission/auth/config error — don't retry these
             if any(keyword in error_lower for keyword in [
                 "permission denied",
                 "403",
@@ -424,11 +454,15 @@ class GitManager:
                 "could not read username",
                 "invalid credentials",
                 "authorization failed",
+                "does not appear to be a git repository",
+                "could not read from remote repository",
+                "repository not found",
             ]):
                 _LOGGER.error(
-                    "Push failed due to authentication/permission error. "
-                    "Check your Personal Access Token permissions (needs 'repo' scope for GitHub). "
-                    "Error: %s",
+                    "Push failed due to authentication/permission/configuration error. "
+                    "Check: 1) Remote URL is correct, "
+                    "2) Repository exists on GitHub, "
+                    "3) PAT has 'repo' scope. Error: %s",
                     err,
                 )
                 raise
@@ -511,6 +545,14 @@ class GitManager:
         Returns:
             Number of commits pulled.
         """
+        # Pre-check: verify remote is configured
+        if not await self.is_remote_configured():
+            raise GitError(
+                "Remote 'origin' is not configured. "
+                "Please set a valid remote URL in the integration options "
+                "(Settings → Devices & Services → git-ha-ppens → Configure)."
+            )
+
         # Backup uncommitted changes before pull
         if backup:
             porcelain = await self._run_git("status", "--porcelain")


### PR DESCRIPTION
## Summary

- Adds `is_remote_configured()` and `get_remote_url()` methods to `GitManager` for pre-validating the remote before any push/pull operation
- `push()` and `pull()` now fail fast with a clear, actionable error message when no remote is configured, instead of cascading through 3 identical failures that flood the logs
- Adds "does not appear to be a git repository", "could not read from remote repository", and "repository not found" to the non-retryable error list so attempt 2/3 are skipped for config errors
- `__init__.py` now verifies the remote was actually set correctly after `set_remote()`/`configure_token_auth()`, and disables push/pull if verification fails

## Test plan

- [ ] Configure integration without a remote URL → push service call should show clear "not configured" error, no cascade
- [ ] Configure integration with an invalid remote URL → setup logs should show verification failure, push is disabled
- [ ] Configure integration with a valid remote URL + token → remote verified in logs, push works normally
- [ ] Check HA logs: errors should be actionable single messages, not 3x the same fatal error

https://claude.ai/code/session_01FG8AV1Tt3iMTf8oakzyUaf