### PR TITLE
Fix commit messages missing first letter of filename

### DIFF
--- a/custom_components/git_ha_ppens/git_manager.py
+++ b/custom_components/git_ha_ppens/git_manager.py
@@ -104,7 +104,7 @@ class GitManager:
                 },
             )
             stdout_bytes, stderr_bytes = await process.communicate()
-            stdout = stdout_bytes.decode("utf-8", errors="replace").strip()
+            stdout = stdout_bytes.decode("utf-8", errors="replace").rstrip()
             stderr = (
                 stderr_bytes.decode("utf-8", errors="replace").strip()
                 if stderr_bytes


### PR DESCRIPTION
## Summary

- **Bug:** Alle automatischen Commit-Messages haben den ersten Buchstaben des Dateinamens verloren (z.B. "Auto: onfiguration.yaml changed" statt "Auto: configuration.yaml changed")
- **Ursache:** `_run_git()` verwendete `.strip()` auf der Git-Ausgabe, was das führende Leerzeichen aus `git status --porcelain` entfernte. Bei nicht-gestageten Änderungen ist Position 0 ein Leerzeichen (z.B. ` M configuration.yaml`). Nach dem Strippen verschob sich das Parsing um ein Zeichen, sodass `line[3:]` den ersten Buchstaben des Dateinamens übersprang.
- **Fix:** `.strip()` → `.rstrip()` — entfernt weiterhin abschließende Zeilenumbrüche, bewahrt aber das führende Leerzeichen

## Test plan

- [ ] Verify `git status --porcelain` output is correctly parsed (leading space preserved)
- [ ] Trigger an automatic commit and confirm the message reads e.g. "Auto: configuration.yaml changed"
- [ ] Confirm no regression in other `_run_git()` callers (branch names, commit hashes, etc.)

https://claude.ai/code/session_01LJNGHYsNqWW6AK1yJVSudh