### PR TITLE
Add automated release workflow for HACS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from manifest
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' custom_components/git_ha_ppens/manifest.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ steps.version.outputs.version }} already exists. Update the version in manifest.json first."
+            exit 1
+          fi
+
+      - name: Create zip
+        run: |
+          cd custom_components/git_ha_ppens
+          zip -r ../../git_ha_ppens.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: git_ha_ppens.zip

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [💡 Example Automations](#-example-automations)
 - [🛡️ Auto-Generated .gitignore](#️-auto-generated-gitignore)
 - [🔧 Troubleshooting](#-troubleshooting)
+- [📦 Release erstellen](#-release-erstellen)
 - [🤝 Contributing](#-contributing)
 - [📄 License](#-license)
 
@@ -315,6 +316,29 @@ Go to **Settings → Devices & Services → git-ha-ppens → Configure** and set
 - Ensure `secrets.yaml` is listed in `.gitignore` (it is by default)
 - The detection uses regex patterns for common key formats (API keys, tokens, passwords)
 </details>
+
+---
+
+## 📦 Release erstellen
+
+Um eine neue Version zu veröffentlichen:
+
+1. **Version hochsetzen** in `custom_components/git_ha_ppens/manifest.json` → Feld `"version"` anpassen (z. B. `"1.0.0"`)
+2. **Änderungen committen und auf `main` pushen**
+3. **`main` in den Branch `release` mergen:**
+   ```bash
+   git checkout release
+   git merge main
+   git push origin release
+   ```
+4. Der GitHub Actions Workflow erstellt automatisch:
+   - Ein Git-Tag `v1.0.0`
+   - Ein GitHub Release mit automatisch generierten Release Notes
+   - Eine `git_ha_ppens.zip` als Download-Asset
+
+> 💡 **Wichtig:** Die Version in `manifest.json` muss bei jedem Release erhöht werden. Der Workflow bricht ab, wenn das Tag bereits existiert.
+
+HACS erkennt das neue Release automatisch und bietet es Nutzern als Update an.
 
 ---
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "git-ha-ppens",
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": true,
+  "filename": "git_ha_ppens.zip"
 }


### PR DESCRIPTION
## Summary

- **Neuer GitHub Actions Workflow** (`.github/workflows/release.yml`): Triggert automatisch bei Push/Merge auf den `release` Branch, liest die Version aus `manifest.json`, erstellt eine `git_ha_ppens.zip` und veröffentlicht ein GitHub Release mit Tag und Zip-Asset
- **hacs.json aktualisiert**: `zip_release: true` und `filename` hinzugefügt für HACS-kompatible Zip-Releases
- **README erweitert**: Abschnitt "Release erstellen" mit Schritt-für-Schritt-Anleitung

## Workflow

1. Version in `manifest.json` hochsetzen
2. Auf `main` committen und pushen
3. `main` in `release` Branch mergen
4. Workflow erstellt automatisch Tag + GitHub Release + .zip

## Test plan

- [ ] Workflow-YAML auf korrekte Syntax prüfen
- [ ] Branch `release` erstellen und Test-Merge durchführen
- [ ] GitHub Actions Tab prüfen ob Workflow startet und erfolgreich durchläuft
- [ ] GitHub Releases prüfen ob Release mit `git_ha_ppens.zip` Asset erstellt wurde
- [ ] HACS-Integration testen ob neue Version erkannt wird

https://claude.ai/code/session_01K4ibYTTkQjYADwQ7F5e28y