### PR TITLE
Add version number to release zip filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create zip
         run: |
           cd custom_components/git_ha_ppens
-          zip -r ../../git_ha_ppens.zip .
+          zip -r ../../git_ha_ppens_${{ steps.version.outputs.version }}.zip .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -41,4 +41,4 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
-          files: git_ha_ppens.zip
+          files: git_ha_ppens_${{ steps.version.outputs.version }}.zip


### PR DESCRIPTION
The zip artifact is now named git_ha_ppens_<version>.zip (e.g. git_ha_ppens_0.1.0.zip) instead of the static git_ha_ppens.zip.

https://claude.ai/code/session_01VRhpDJH5jHFVjFUK8KFKXQ