### PR TITLE
Upload both versioned and static zip to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           cd custom_components/git_ha_ppens
           zip -r ../../git_ha_ppens_${{ steps.version.outputs.version }}.zip .
+          zip -r ../../git_ha_ppens.zip .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -41,4 +42,6 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
-          files: git_ha_ppens_${{ steps.version.outputs.version }}.zip
+          files: |
+            git_ha_ppens_${{ steps.version.outputs.version }}.zip
+            git_ha_ppens.zip


### PR DESCRIPTION
HACS requires a static filename (git_ha_ppens.zip) as configured in hacs.json. Both git_ha_ppens_<version>.zip and git_ha_ppens.zip are now uploaded to each release so HACS can download the integration while humans still get the versioned artifact.

https://claude.ai/code/session_01VRhpDJH5jHFVjFUK8KFKXQ