### PR TITLE
Improve .gitignore defaults and documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 manuveli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
 - [💡 Example Automations](#-example-automations)
 - [🛡️ Auto-Generated .gitignore](#️-auto-generated-gitignore)
 - [🔧 Troubleshooting](#-troubleshooting)
-- [📦 Release erstellen](#-release-erstellen)
 - [🤝 Contributing](#-contributing)
 - [📄 License](#-license)
 
@@ -269,9 +268,11 @@ The integration automatically creates or updates `.gitignore` with sensible defa
 | Category | Entries |
 |----------|---------|
 | **Sensitive files** | `secrets.yaml`, `.storage/`, `.cloud/`, `tls/`, `.jwt_secret`, `SERVICE_ACCOUNT.json` |
-| **Databases & logs** | `*.db`, `*.log`, `home-assistant_v2.db`, `home-assistant.log*`, `zigbee.db`, `OZW_Log.txt` |
-| **Runtime & cache** | `__pycache__/`, `deps/`, `tts/`, `.venv/`, `.cache/`, `custom_components/` |
+| **Databases & logs** | `*.db`, `*.db-shm`, `*.db-wal`, `*.log`, `home-assistant_v2.db`, `home-assistant.log*`, `zigbee.db`, `OZW_Log.txt` |
 | **System files** | `.HA_VERSION`, `known_devices.yaml`, `ip_bans.yaml` |
+| **Python cache** | `__pycache__/`, `*.pyc`, `*.pyo` |
+| **Runtime & other** | `.git/`, `deps/`, `tts/`, `.venv/`, `.cache/`, `.claude/`, `custom_components/`, `www/snapshots/`, `.ha_run.lock`, `.exports`, `.timeline`, `.vacuum` |
+| **Zigbee2MQTT** | `zigbee2mqtt/state.json`, `zigbee2mqtt/coordinator_backup.json` |
 
 > 📌 Existing `.gitignore` entries are preserved — only missing defaults are appended.
 
@@ -316,29 +317,6 @@ Go to **Settings → Devices & Services → git-ha-ppens → Configure** and set
 - Ensure `secrets.yaml` is listed in `.gitignore` (it is by default)
 - The detection uses regex patterns for common key formats (API keys, tokens, passwords)
 </details>
-
----
-
-## 📦 Release erstellen
-
-Um eine neue Version zu veröffentlichen:
-
-1. **Version hochsetzen** in `custom_components/git_ha_ppens/manifest.json` → Feld `"version"` anpassen (z. B. `"1.0.0"`)
-2. **Änderungen committen und auf `main` pushen**
-3. **`main` in den Branch `release` mergen:**
-   ```bash
-   git checkout release
-   git merge main
-   git push origin release
-   ```
-4. Der GitHub Actions Workflow erstellt automatisch:
-   - Ein Git-Tag `v1.0.0`
-   - Ein GitHub Release mit automatisch generierten Release Notes
-   - Eine `git_ha_ppens.zip` als Download-Asset
-
-> 💡 **Wichtig:** Die Version in `manifest.json` muss bei jedem Release erhöht werden. Der Workflow bricht ab, wenn das Tag bereits existiert.
-
-HACS erkennt das neue Release automatisch und bietet es Nutzern als Update an.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR enhances the `.gitignore` generation defaults and improves documentation by expanding coverage of Home Assistant-specific files and adding a LICENSE file.

## Key Changes
- **Expanded .gitignore defaults**: Added more comprehensive entries for database files (`*.db-shm`, `*.db-wal`), Python cache files (`*.pyc`, `*.pyo`), and Home Assistant-specific directories (`.claude/`, `www/snapshots/`, `.ha_run.lock`, `.exports`, `.timeline`, `.vacuum`)
- **Reorganized .gitignore categories**: Split "Runtime & cache" into separate "Python cache" and "Runtime & other" categories for better clarity
- **Added Zigbee2MQTT support**: New category for Zigbee2MQTT-specific files (`state.json`, `coordinator_backup.json`)
- **Removed German release documentation**: Deleted the "📦 Release erstellen" section from README as it appears to be internal process documentation
- **Added MIT LICENSE file**: Included proper license file for the project

## Implementation Details
The `.gitignore` defaults now provide more complete coverage for Home Assistant installations, including SQLite WAL files (which are created alongside `.db` files), Python bytecode artifacts, and various Home Assistant runtime files. The reorganized categories make the documentation clearer and easier to maintain.

https://claude.ai/code/session_01LGGjd24fx8ipQ1FsefywoN